### PR TITLE
Fix 'nmp' typo in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,7 @@ npm i
 npm run build -ws
 ```
 
-**Note**: We have included a `package-lock.json` in `script/workspace`. If `npm run build -ws` fails because packages are not installed correctly with `nmp i`, re-run `script/bootstrap` and run `npm ci` to
+**Note**: We have included a `package-lock.json` in `script/workspace`. If `npm run build -ws` fails because packages are not installed correctly with `npm i`, re-run `script/bootstrap` and run `npm ci` to
 get working packages.
 
 ## Make changes


### PR DESCRIPTION
Following the development.md instructions, there is an instance where 'npm' is mistakenly written as 'nmp'